### PR TITLE
RF-12481 - Added example code to verify bug:

### DIFF
--- a/input-demo/src/main/webapp/examples/autocomplete.xhtml
+++ b/input-demo/src/main/webapp/examples/autocomplete.xhtml
@@ -25,7 +25,10 @@
         <f:selectItems value="#{autoCompleteBean.modes}"/>
     </h:selectOneMenu>
     <br/>
-
+    <h:commandButton accesskey="b" value="RF-12481" title="Click when Autocomplete is expanded" >
+        <f:ajax execute="@form" render="@form"/>
+    </h:commandButton>
+    <br/>
     <div style="height: 300px; width: 300px; overflow: auto; float: left;">
         Text block text block text block text block text block text block text block text block
         <script type="text/javascript">

--- a/input-demo/src/main/webapp/examples/autocomplete.xhtml
+++ b/input-demo/src/main/webapp/examples/autocomplete.xhtml
@@ -25,6 +25,10 @@
         <f:selectItems value="#{autoCompleteBean.modes}"/>
     </h:selectOneMenu>
     <br/>
+    <h:commandButton accesskey="b" value="RF-12481" title="Click when Autocomplete is expanded" >
+    	<f:ajax execute="@form" render="@form"/>
+    </h:commandButton>
+    <br/>
 
     <div style="height: 300px; width: 300px; overflow: auto; float: left;">
         Text block text block text block text block text block text block text block text block

--- a/input-demo/src/main/webapp/examples/autocomplete.xhtml
+++ b/input-demo/src/main/webapp/examples/autocomplete.xhtml
@@ -26,10 +26,9 @@
     </h:selectOneMenu>
     <br/>
     <h:commandButton accesskey="b" value="RF-12481" title="Click when Autocomplete is expanded" >
-    	<f:ajax execute="@form" render="@form"/>
+        <f:ajax execute="@form" render="@form"/>
     </h:commandButton>
     <br/>
-
     <div style="height: 300px; width: 300px; overflow: auto; float: left;">
         Text block text block text block text block text block text block text block text block
         <script type="text/javascript">


### PR DESCRIPTION
Autocomplete - does not close the popup in destroy method.
The Suggestion popup is left hanging on the page.
If an Autocomplete is rendered while the item list is shown, the destroy method is not closing the item list (popup box). The item list is left hanging on the page.
The only way to remove the items is to refresh the whole page.
